### PR TITLE
fix: resolve review data loading issue in RAG system

### DIFF
--- a/st_app/db/faiss_index/meta.json
+++ b/st_app/db/faiss_index/meta.json
@@ -11,5 +11,5 @@
         "preprocessed_reviews_googlemap.csv",
         "preprocessed_reviews_kakaomap.csv"
     ],
-    "docs_path": "/Users/chojaegwan/Desktop/Ybigta/YBIGTA_newbie_team_project/st_app/db/faiss_index/docs.jsonl"
+    "docs_path": "docs.jsonl"
 }

--- a/st_app/rag/retriever.py
+++ b/st_app/rag/retriever.py
@@ -31,6 +31,9 @@ class ReviewRetriever:
 
         # docs.jsonl 로드
         docs_path = meta.get("docs_path", os.path.join(INDEX_DIR, "docs.jsonl"))
+        # 상대 경로인 경우 INDEX_DIR을 기준으로 절대 경로 생성
+        if not os.path.isabs(docs_path):
+            docs_path = os.path.join(INDEX_DIR, docs_path)
         if not os.path.exists(docs_path):
             raise FileNotFoundError(f"docs.jsonl 없음: {docs_path}")
 


### PR DESCRIPTION
- Fix absolute path issue in meta.json by changing docs_path to relative path
- Add path resolution logic in ReviewRetriever to handle relative paths correctly
- Ensure FAISS index and review data load properly across different environments
- Resolve FileNotFoundError when loading docs.jsonl in different user environments

This fix allows the RAG system to work correctly regardless of the user's file system path, making the application more portable and reliable.